### PR TITLE
feat(agno): upgrade to v2.6.5 and add @approval decorator example

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ This repository provides a comprehensive, hands-on comparison of modern AI agent
           <img src="res/agno.svg" alt="Agno" width="68" style="vertical-align: middle;">
         </picture>
       </td>
-      <td><code>2.5.17</code></td>
+      <td><code>2.6.5</code></td>
       <td>
           <a href="https://docs.agno.com/introduction">
             <picture>
@@ -425,7 +425,7 @@ This repository provides a comprehensive, hands-on comparison of modern AI agent
           <img src="res/strands-amazon-sdk.svg" alt="Strands Agents SDK" width="120" style="vertical-align: middle;">
         </picture>
       </td>
-      <td><code>1.35.0</code></td>
+      <td><code>1.39.0</code></td>
       <td>
           <a href="https://strandsagents.com/latest/">
             <picture>

--- a/agno/16_approval_decorator.py
+++ b/agno/16_approval_decorator.py
@@ -25,7 +25,7 @@ composable decorator that supports both required (blocking)
 and audit (non-blocking) approval types.
 
 For more details, visit:
-https://docs.agno.com/agents/human-in-the-loop
+https://docs.agno.com/runtime/human-approval
 -------------------------------------------------------
 """
 

--- a/agno/16_approval_decorator.py
+++ b/agno/16_approval_decorator.py
@@ -1,0 +1,101 @@
+from dotenv import load_dotenv
+
+from agno.agent import Agent
+from agno.approval import ApprovalType
+from agno.approval.decorator import approval
+from agno.models.openai import OpenAIChat
+from agno.tools import tool
+from agno.utils.pprint import pprint_run_response
+
+from settings import settings
+
+load_dotenv()
+
+"""
+-------------------------------------------------------
+In this example, we explore Agno with the following features:
+- The @approval decorator for tool-level HITL gating
+- ApprovalType.required for blocking approval before execution
+- Composing @approval with @tool in either order
+
+The @approval decorator (new in Agno 2.6.x) provides a cleaner
+way to mark tools as requiring human approval. It replaces the
+older requires_confirmation=True pattern on @tool with a
+composable decorator that supports both required (blocking)
+and audit (non-blocking) approval types.
+
+For more details, visit:
+https://docs.agno.com/agents/human-in-the-loop
+-------------------------------------------------------
+"""
+
+
+# --- 1. Define tools with @approval decorator ---
+@approval
+@tool
+def delete_file(filename: str) -> str:
+    """Delete a file from the system.
+
+    Args:
+        filename: The name of the file to delete.
+
+    Returns:
+        Confirmation that the file was deleted.
+    """
+    return f"File '{filename}' has been deleted."
+
+
+@tool
+def list_files() -> str:
+    """List all files in the current directory.
+
+    Returns:
+        A list of files.
+    """
+    return "Files: report.pdf, notes.txt, budget.xlsx, photo.jpg"
+
+
+# --- 2. Create the agent ---
+agent = Agent(
+    model=OpenAIChat(id=settings.OPENAI_MODEL_NAME),
+    tools=[delete_file, list_files],
+    instructions=[
+        "You are a file management assistant.",
+        "When asked to delete files, use the delete_file tool.",
+        "When asked to list files, use the list_files tool.",
+        "Be concise in your responses.",
+    ],
+    markdown=True,
+)
+
+# --- 3. Run a safe operation (no approval needed) ---
+print("=== Example 1: Safe operation (list files) ===\n")
+run_output = agent.run("List all the files.")
+pprint_run_response(run_output)
+
+# --- 4. Run a destructive operation (approval required) ---
+print("\n=== Example 2: Destructive operation (delete file — needs approval) ===\n")
+run_output = agent.run("Delete the file notes.txt")
+pprint_run_response(run_output)
+
+# Check for pending requirements
+if run_output.requirements:
+    print(f"\nPending approvals: {len(run_output.requirements)}")
+    for req in run_output.requirements:
+        tool_exec = req.tool_execution
+        if tool_exec:
+            print(f"  Tool: {tool_exec.tool_name}")
+            print(f"  Args: {tool_exec.tool_args}")
+
+    # Approve and continue
+    for req in run_output.requirements:
+        req.confirm()
+
+    print("\n=== Continuing after approval ===\n")
+    continued_output = agent.continue_run(
+        run_response=run_output,
+        requirements=run_output.requirements,
+    )
+    pprint_run_response(continued_output)
+else:
+    print("\nNo approval needed — tool executed directly.")

--- a/agno/OUTPUTS.md
+++ b/agno/OUTPUTS.md
@@ -1,6 +1,6 @@
 # Agno Example Outputs
 
-Captured outputs from running all 16 examples against agno v2.5.17 with `gpt-4o-mini`.
+Captured outputs from running all 17 examples against agno v2.6.5 with `gpt-4o-mini`.
 
 > These outputs may vary between runs due to LLM non-determinism. The structure and tool invocations should remain consistent.
 
@@ -438,3 +438,37 @@ Secure MCP Filesystem Server running on stdio
   3. [INPUT] Who invented the telephone?
   4. [OUTPUT] The telephone was invented by Alexander Graham Bell in 1876.
 ```
+
+---
+
+## 16_approval_decorator.py
+
+```
+=== Example 1: Safe operation (list files) ===
+
+╭─────────────────────────────────────╮
+│ ### Files in the current directory: │
+│ - `report.pdf`                      │
+│ - `notes.txt`                       │
+│ - `budget.xlsx`                     │
+│ - `photo.jpg`                       │
+╰─────────────────────────────────────╯
+
+=== Example 2: Destructive operation (delete file — needs approval) ===
+
+╭───────────────────────────────────────────────────╮
+│ I have tools to execute, but I need confirmation. │
+╰───────────────────────────────────────────────────╯
+
+Pending approvals: 1
+  Tool: delete_file
+  Args: {'filename': 'notes.txt'}
+
+=== Continuing after approval ===
+
+╭──────────────────────────────────────────╮
+│ The file **notes.txt** has been deleted. │
+╰──────────────────────────────────────────╯
+```
+
+> The @approval decorator gates the delete_file tool behind human approval while list_files executes freely.

--- a/agno/README.md
+++ b/agno/README.md
@@ -2,6 +2,7 @@
 
 - Repo: https://github.com/agno-agi/agno
 - Documentation: https://docs.agno.com
+- Version: **2.6.5**
 
 ## Agno Examples
 
@@ -58,6 +59,7 @@ cp .env.example .env
 | 13 | `13_session_state.py` | Session State | Stateful tools with `session_state` |
 | 14 | `14_mcp_tools.py` | MCP Tools | External tool servers via Model Context Protocol |
 | 15 | `15_hooks.py` | Hooks | Pre-hooks and post-hooks for logging and transforms |
+| 16 | `16_approval_decorator.py` | Approval | `@approval` decorator for tool-level HITL gating |
 
 ### Running examples
 


### PR DESCRIPTION
## Summary

This PR upgrades Agno from `2.5.17` to `2.6.5` and adds a new example showcasing the `@approval` decorator for composable human-in-the-loop gating.

---

## What changed

### Package upgrade

- `agno` upgraded from `2.5.17` → `2.6.5`

### New examples added

| File | Feature | Docs |
|------|---------|------|
| `16_approval_decorator.py` | `@approval` decorator — composable HITL gating on agent tools | [Human Approval](https://docs.agno.com/runtime/human-approval) |

### Key changes in v2.5.17 → v2.6.5

- **Context Providers** (`agno.context`) — first-party API to plug external sources (filesystem, Slack, GDrive, Gmail, Calendar, MCP) into agents
- **Team HITL + Approvals** — human-in-the-loop and approval gates for Teams, not just Agents
- **Agent/Team/Workflow Factories** — dynamic runtime creation for multi-tenant scenarios
- **Workspace Tools** — read/write/edit/shell on a root dir, destructive ops gated by HITL
- **Claude multi-block prompt caching** — `system_prompt_blocks` with per-block `cache`/`ttl`
- **ParallelMCPBackend** — web search via Parallel's MCP server
- **SSE reconnection/resume** — background agent/team runs can be reconnected after interruption
- **Breaking: `"openai:"` prefix now resolves to `OpenAIResponses`** — use `"openai-chat:"` for old behavior

### Notes

Several v2.6.x features (Context Providers, Workspace Tools, Factories) are part of the AgentOS server-side layer rather than the client SDK. The `@approval` decorator was the primary new client-side feature available for standalone examples.

## Configuration

- All examples use **OpenAI** (`gpt-4o-mini`) via `settings.py`
- Dependencies: `agno>=2.6.5`, `pydantic-settings`
- Managed with `uv` package manager

## Testing

All 17 examples follow repo conventions and are verified against v2.6.5 (see `OUTPUTS.md` for captured output).