### PR TITLE
feat(agno): upgrade to v2.8.7 and add 3 new examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ This repository provides a comprehensive, hands-on comparison of modern AI agent
           <img src="res/agno.svg" alt="Agno" width="68" style="vertical-align: middle;">
         </picture>
       </td>
-      <td><code>2.6.18</code></td>
+      <td><code>2.8.7</code></td>
       <td>
           <a href="https://docs.agno.com/introduction">
             <picture>

--- a/agno/11_guardrails.py
+++ b/agno/11_guardrails.py
@@ -3,7 +3,7 @@ from typing import Union
 from dotenv import load_dotenv
 
 from agno.agent import Agent
-from agno.agent._hooks import InputCheckError
+from agno.exceptions import InputCheckError
 from agno.guardrails import BaseGuardrail
 from agno.models.openai import OpenAIChat
 from agno.run.agent import RunInput

--- a/agno/16_approval_decorator.py
+++ b/agno/16_approval_decorator.py
@@ -1,7 +1,6 @@
 from dotenv import load_dotenv
 
 from agno.agent import Agent
-from agno.approval import ApprovalType
 from agno.approval.decorator import approval
 from agno.models.openai import OpenAIChat
 from agno.tools import tool

--- a/agno/17_checkpointing.py
+++ b/agno/17_checkpointing.py
@@ -1,0 +1,158 @@
+import os
+
+from dotenv import load_dotenv
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+from agno.tools import tool
+from agno.utils.pprint import pprint_run_response
+
+from settings import settings
+
+load_dotenv()
+
+"""
+-------------------------------------------------------
+In this example, we explore Agno with the following features:
+- Checkpointing with Agent(checkpoint="tool-batch")
+- Recovering a run that died mid-flight with continue_run(run_id=...)
+- Branching a conversation with fork_session()
+
+By default an agent only writes to its database at terminal states, so a
+process that dies mid-run loses every tool result it had already paid for.
+With checkpoint="tool-batch" the run state is written after each model turn,
+so a crashed run can be resumed in place from the last checkpoint. This is
+different from the paused runs in 07_human_in_the_loop.py and
+16_approval_decorator.py: nothing asked for permission here, the process
+simply went away.
+
+For more details, visit:
+https://docs.agno.com/examples/agents/checkpointing/crash-recovery
+-------------------------------------------------------
+"""
+
+DB_FILE = "/tmp/agno_checkpointing_example.db"
+SESSION_ID = "invoice-audit-session-001"
+
+# Start from a clean database so the example is reproducible.
+if os.path.exists(DB_FILE):
+    os.remove(DB_FILE)
+
+
+# --- 1. Simulate a process that dies mid-run ---
+class SimulatedCrash(BaseException):
+    """Stands in for a SIGKILL'd worker.
+
+    It derives from BaseException, not Exception, so Agno's tool error handling
+    does not catch it and feed it back to the model — it tears the run down the
+    way a real crash would.
+    """
+
+
+crash_armed = True
+
+# Counts real tool invocations, to prove what the resume did NOT have to redo.
+call_counts = {"list_invoices": 0, "fetch_invoice_total": 0}
+
+
+# --- 2. Define expensive tools ---
+@tool
+def list_invoices(region: str) -> str:
+    """List the invoice ids for a region.
+
+    Args:
+        region: The sales region to list invoices for.
+
+    Returns:
+        The invoice ids found for that region.
+    """
+    call_counts["list_invoices"] += 1
+    print(f"   [tool] list_invoices({region!r}) — expensive call #{call_counts['list_invoices']}")
+    return f"Invoices for {region}: INV-101, INV-102"
+
+
+@tool
+def fetch_invoice_total(invoice_id: str) -> str:
+    """Fetch the total amount of a single invoice.
+
+    Args:
+        invoice_id: The id of the invoice to fetch.
+
+    Returns:
+        The invoice total in EUR.
+    """
+    call_counts["fetch_invoice_total"] += 1
+    print(f"   [tool] fetch_invoice_total({invoice_id!r}) — expensive call #{call_counts['fetch_invoice_total']}")
+    if crash_armed:
+        raise SimulatedCrash("worker process killed while fetching invoice totals")
+    totals = {"INV-101": 1200, "INV-102": 1200}
+    return f"{invoice_id} total: {totals.get(invoice_id, 0)} EUR"
+
+
+# --- 3. Create the agent with checkpointing enabled ---
+agent = Agent(
+    model=OpenAIChat(id=settings.OPENAI_MODEL_NAME),
+    db=SqliteDb(db_file=DB_FILE),
+    checkpoint="tool-batch",
+    tools=[list_invoices, fetch_invoice_total],
+    add_history_to_context=True,
+    num_history_runs=5,
+    instructions=[
+        "First list the invoices for the region, then fetch the total of every invoice id you found.",
+        "Answer in one plain sentence. No bullet lists, no formulas.",
+    ],
+    markdown=True,
+)
+
+# --- 4. The run crashes after the first tool batch ---
+print("=== Step 1: Run crashes mid-flight ===\n")
+try:
+    agent.run("What is the combined invoice total for Iberia?", session_id=SESSION_ID)
+except SimulatedCrash as error:
+    print(f"\n💥 Process died: {error}")
+
+# --- 5. Inspect what survived in the database ---
+print("\n=== Step 2: What the checkpoint saved ===\n")
+crashed_run = agent.get_last_run_output(session_id=SESSION_ID)
+print(f"Run id:      {crashed_run.run_id}")
+print(f"Run status:  {crashed_run.status}  (never reached a terminal state)")
+print("Tool results already persisted:")
+for tool_execution in crashed_run.tools or []:
+    print(f"  - {tool_execution.tool_name}: {tool_execution.result}")
+
+# --- 6. Resume the crashed run in place ---
+# Same run_id: the agent picks up from the checkpoint instead of starting over.
+print("\n=== Step 3: Resume the crashed run ===\n")
+crash_armed = False
+resumed_output = agent.continue_run(run_id=crashed_run.run_id, session_id=SESSION_ID)
+pprint_run_response(resumed_output)
+
+print(f"\nRun status: {resumed_output.status}")
+print(f"list_invoices calls (whole example): {call_counts['list_invoices']}")
+print("  -> the resume replayed the checkpointed result instead of calling it again")
+
+# --- 7. Branch the finished conversation into a new session ---
+# fork_session deep-copies every run into a fresh session_id, so an alternative
+# follow-up can be explored without polluting the audited original.
+print("\n=== Step 4: Fork the session to explore a branch ===\n")
+forked_session_id = agent.fork_session(source_session_id=SESSION_ID)
+print(f"Forked '{SESSION_ID}' -> '{forked_session_id}'\n")
+
+calls_before_branch = call_counts["fetch_invoice_total"]
+
+branch_output = agent.run(
+    "Using only the totals you already fetched, what is the average invoice amount?",
+    session_id=forked_session_id,
+)
+pprint_run_response(branch_output)
+
+original_runs = len(agent.get_session(session_id=SESSION_ID).runs or [])
+forked_runs = len(agent.get_session(session_id=forked_session_id).runs or [])
+print(f"\nRuns in original session: {original_runs} (untouched)")
+print(f"Runs in forked session:   {forked_runs} (inherited history + the branch)")
+print(
+    f"fetch_invoice_total calls: {calls_before_branch} before the fork, "
+    f"{call_counts['fetch_invoice_total']} after the branch"
+)
+print("  -> the branch answered from the forked history, no tool re-run")

--- a/agno/18_filesystem.py
+++ b/agno/18_filesystem.py
@@ -1,0 +1,105 @@
+import os
+
+from dotenv import load_dotenv
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.fs import FileSystem
+from agno.models.openai import OpenAIChat
+from agno.utils.pprint import pprint_run_response
+
+from settings import settings
+
+load_dotenv()
+
+"""
+-------------------------------------------------------
+In this example, we explore Agno with the following features:
+- agno.fs.FileSystem — a durable, private file store for the agent
+- fs.tools() to attach the file tools and fs.instructions() to compose their guidance
+- A templated namespace ("notes/{user_id}") that isolates each user's files
+- Programmatic access to the same store with fs.read() / fs.list() / fs.usage()
+
+FileSystem is a third kind of agent state, orthogonal to the two already covered
+here: 10_storage.py persists conversation transcripts, and 13_session_state.py
+holds an ephemeral dict for the length of a session. FileSystem gives the agent
+prose it writes for itself — notes that outlive any single session, stored in the
+same SqliteDb and isolated per user by namespace.
+
+For more details, visit:
+https://docs.agno.com/filesystem/overview
+-------------------------------------------------------
+"""
+
+DB_FILE = "/tmp/agno_filesystem_example.db"
+
+# Start from a clean database so the example is reproducible.
+if os.path.exists(DB_FILE):
+    os.remove(DB_FILE)
+
+# --- 1. Back the file store with the same database as the sessions ---
+db = SqliteDb(db_file=DB_FILE)
+
+# "{user_id}" is resolved per tool call from the run context, never from a model
+# argument, and fails closed when the run has no user_id.
+fs = FileSystem(db, namespace="notes/{user_id}")
+
+# --- 2. Attach the tools and compose the instructions ---
+agent = Agent(
+    model=OpenAIChat(id=settings.OPENAI_MODEL_NAME),
+    db=db,
+    tools=[fs.tools()],
+    instructions=[
+        "You are a research assistant who keeps durable notes about each user's project.",
+        "Record lasting facts the user tells you in notes/project.md, and re-read your notes before answering.",
+        "If your notes do not cover the question, say you have no note on it. Never guess.",
+        "Keep replies to one or two sentences.",
+        fs.instructions(),
+    ],
+    markdown=True,
+)
+
+# --- 3. Session 1: the agent writes a note ---
+print("=== Session 1 (user: alice) — record a durable fact ===\n")
+run_output = agent.run(
+    "I'm benchmarking vector databases for a RAG pipeline. We settled on LanceDb "
+    "because it runs embedded with no server. Note that down.",
+    user_id="alice",
+    session_id="alice-session-1",
+)
+pprint_run_response(run_output)
+
+# --- 4. Session 2: a brand-new session with no conversation history ---
+# Nothing carries over except the file store, so an answer here can only come
+# from the note written above.
+print("\n=== Session 2 (user: alice, new session) — recall from the file store ===\n")
+run_output = agent.run(
+    "Which vector database did we pick, and why?",
+    user_id="alice",
+    session_id="alice-session-2",
+)
+pprint_run_response(run_output)
+
+# --- 5. A different user hits the same agent and the same database ---
+print("\n=== Session 3 (user: bob) — namespace isolation ===\n")
+run_output = agent.run(
+    "Which vector database did we pick, and why?",
+    user_id="bob",
+    session_id="bob-session-1",
+)
+pprint_run_response(run_output)
+
+# --- 6. Inspect the store programmatically ---
+# resolve() binds the templated namespace outside of a run.
+print("\n=== The store, seen from outside the agent ===\n")
+for user_id in ("alice", "bob"):
+    user_fs = fs.resolve(user_id=user_id)
+    files = user_fs.list()
+    usage = user_fs.usage()
+    print(f"namespace 'notes/{user_id}': {usage.file_count} file(s), {usage.total_bytes} bytes")
+    for meta in files:
+        print(f"  - {meta.path} ({meta.size_bytes} bytes, version {meta.version})")
+
+alice_note = fs.resolve(user_id="alice").read("notes/project.md")
+print("\nContents of alice's notes/project.md:")
+print(alice_note)

--- a/agno/19_eval_suite.py
+++ b/agno/19_eval_suite.py
@@ -1,0 +1,126 @@
+from dotenv import load_dotenv
+from pydantic import BaseModel, Field
+
+from agno.agent import Agent
+from agno.eval.suite import Case, run_cases
+from agno.models.openai import OpenAIChat
+from agno.scorer import CodeScorer, ToolCallScorer
+from agno.tools import tool
+
+from settings import settings
+
+load_dotenv()
+
+"""
+-------------------------------------------------------
+In this example, we explore Agno with the following features:
+- agno.eval.suite.Case to declare eval cases and run_cases() to execute them
+- CodeScorer to grade a typed answer against an expected value in plain Python
+- ToolCallScorer to assert which tools actually executed, and with which arguments
+- SuiteResult.to_dict() as the machine-readable payload a CI gate consumes
+
+An eval suite turns "the agent seems fine" into a pass/fail gate. Both scorers
+used here are deterministic and cost nothing beyond the agent's own run — no
+judge model is involved — which makes the suite cheap enough to run on every
+commit. Cases with `criteria=` instead grade with an LLM judge, at the price of
+an extra model call per case.
+
+For more details, visit:
+https://docs.agno.com/evals/suite/overview
+-------------------------------------------------------
+"""
+
+RATES = {"EUR": 1.09, "GBP": 1.27}
+
+
+# --- 1. Define the tool and the output schema under test ---
+@tool
+def get_exchange_rate(currency: str) -> str:
+    """Get the exchange rate of a currency against USD.
+
+    Args:
+        currency: The three-letter currency code, e.g. "EUR".
+
+    Returns:
+        How many USD one unit of that currency is worth.
+    """
+    rate = RATES.get(currency.upper())
+    if rate is None:
+        return f"No rate available for '{currency}'."
+    return f"1 {currency.upper()} = {rate} USD"
+
+
+class Conversion(BaseModel):
+    currency: str = Field(description="The three-letter source currency code.")
+    usd_amount: float = Field(description="The converted amount in USD.")
+
+
+# --- 2. Create the agent under test ---
+agent = Agent(
+    name="currency-converter",
+    model=OpenAIChat(id=settings.OPENAI_MODEL_NAME),
+    tools=[get_exchange_rate],
+    output_schema=Conversion,
+    instructions=[
+        "Always look up the exchange rate with the tool before converting.",
+        "Never convert from memory.",
+    ],
+)
+
+
+# --- 3. A deterministic scorer over the typed output ---
+def usd_amount_matches(run, expected) -> bool:
+    """Pass when the converted amount is within a cent of the expected value.
+
+    `run.content` is the Conversion model, so the check compares a typed field
+    rather than parsing prose.
+    """
+    return abs(run.content.usd_amount - expected) < 0.01
+
+
+# --- 4. Declare the cases ---
+cases = [
+    Case(
+        name="converts 100 EUR correctly",
+        input="Convert 100 EUR to USD.",
+        agent=agent,
+        scorer=CodeScorer(usd_amount_matches),
+        expected=109.0,
+        tags=("currency",),
+    ),
+    Case(
+        name="looks the rate up instead of guessing",
+        input="Convert 50 GBP to USD.",
+        agent=agent,
+        scorer=ToolCallScorer(
+            expected_tools=["get_exchange_rate"],
+            arguments={"get_exchange_rate": {"currency": "GBP"}},
+        ),
+        tags=("currency", "reliability"),
+    ),
+]
+
+# --- 5. Run the suite ---
+print("=== Running eval suite ===\n")
+suite_result = run_cases(cases)
+
+# --- 6. Report ---
+payload = suite_result.to_dict()
+for case_payload in payload["cases"]:
+    verdict = "PASS" if case_payload["passed"] else "FAIL"
+    print(f"[{verdict}] {case_payload['name']}")
+    print(f"  tags:         {', '.join(case_payload['tags'])}")
+    print(f"  tools called: {case_payload['tools_called'] or 'none'}")
+    print(f"  score:        {case_payload['score_value']} (passed={case_payload['score_passed']})")
+    if case_payload["score_reason"]:
+        print(f"  reason:       {case_payload['score_reason']}")
+    print(f"  output:       {case_payload['output']}")
+    print(f"  duration:     {case_payload['duration_seconds']:.2f}s")
+
+summary = payload["summary"]
+print(f"\nSuite: {summary['status']} — {summary['passed']}/{summary['total']} cases passed")
+
+# --- 7. Fail the process on a red suite, the way a CI gate would ---
+# cli() wraps this same runner with argument parsing and exit codes 0/1/2.
+if summary["status"] != "PASS":
+    raise SystemExit(1)

--- a/agno/OUTPUTS.md
+++ b/agno/OUTPUTS.md
@@ -1,12 +1,12 @@
 # Agno Example Outputs
 
-Captured outputs from running all 17 examples against agno v2.6.18 with `gpt-4o-mini`.
+Captured outputs from running all 20 examples against agno v2.8.7 with `gpt-4o-mini`.
 
 > These outputs may vary between runs due to LLM non-determinism. The structure and tool invocations should remain consistent.
 
 ---
 
-## 00_basic_agent.py
+## 00_hello_world.py
 
 ```
 ╭──────────────────────────────────────────────────────────────────────────────╮
@@ -306,13 +306,15 @@ INFO Found 4 documents
 === Test 2: Blocked request (disallowed keyword) ===
 
 ERROR    Validation failed: Request blocked: contains disallowed keyword 'hack'.
+         | Check trigger: CheckTrigger.INPUT_NOT_ALLOWED
 ╭──────────────────────────────────────────────────────╮
 │ Request blocked: contains disallowed keyword 'hack'. │
 ╰──────────────────────────────────────────────────────╯
 
 === Test 3: Blocked request (too long) ===
 
-ERROR    Validation failed: Request blocked: input too long (1200 chars, max 500).
+ERROR    Validation failed: Request blocked: input too long (1200 chars, max
+         500). | Check trigger: CheckTrigger.INPUT_NOT_ALLOWED
 ╭────────────────────────────────────────────────────────╮
 │ Request blocked: input too long (1200 chars, max 500). │
 ╰────────────────────────────────────────────────────────╯
@@ -446,13 +448,13 @@ Secure MCP Filesystem Server running on stdio
 ```
 === Example 1: Safe operation (list files) ===
 
-╭─────────────────────────────────────╮
-│ ### Files in the current directory: │
-│ - `report.pdf`                      │
-│ - `notes.txt`                       │
-│ - `budget.xlsx`                     │
-│ - `photo.jpg`                       │
-╰─────────────────────────────────────╯
+╭─────────────────────────────────╮
+│ ### Files in Current Directory: │
+│ - `report.pdf`                  │
+│ - `notes.txt`                   │
+│ - `budget.xlsx`                 │
+│ - `photo.jpg`                   │
+╰─────────────────────────────────╯
 
 === Example 2: Destructive operation (delete file — needs approval) ===
 
@@ -472,3 +474,113 @@ Pending approvals: 1
 ```
 
 > The @approval decorator gates the delete_file tool behind human approval while list_files executes freely.
+
+---
+
+## 17_checkpointing.py
+
+```
+=== Step 1: Run crashes mid-flight ===
+
+   [tool] list_invoices('Iberia') — expensive call #1
+   [tool] fetch_invoice_total('INV-101') — expensive call #1
+
+💥 Process died: worker process killed while fetching invoice totals
+
+=== Step 2: What the checkpoint saved ===
+
+Run id:      116797cf-ad08-4d51-9f36-b6feda0639af
+Run status:  RUNNING  (never reached a terminal state)
+Tool results already persisted:
+  - list_invoices: Invoices for Iberia: INV-101, INV-102
+
+=== Step 3: Resume the crashed run ===
+
+   [tool] fetch_invoice_total('INV-101') — expensive call #2
+   [tool] fetch_invoice_total('INV-102') — expensive call #3
+╭────────────────────────────────────────────────────╮
+│ The combined invoice total for Iberia is 2400 EUR. │
+╰────────────────────────────────────────────────────╯
+
+Run status: RunStatus.completed
+list_invoices calls (whole example): 1
+  -> the resume replayed the checkpointed result instead of calling it again
+
+=== Step 4: Fork the session to explore a branch ===
+
+Forked 'invoice-audit-session-001' -> '97f80717-d1ed-4b91-87c6-2d50cf74dd7a'
+
+╭────────────────────────────────────────────────────╮
+│ The average invoice amount for Iberia is 1200 EUR. │
+╰────────────────────────────────────────────────────╯
+
+Runs in original session: 1 (untouched)
+Runs in forked session:   2 (inherited history + the branch)
+fetch_invoice_total calls: 3 before the fork, 3 after the branch
+  -> the branch answered from the forked history, no tool re-run
+```
+
+> The call counters are the proof: `list_invoices` ran once in the whole example, so the resumed run read its result from the `tool-batch` checkpoint rather than paying for it twice. Unlike `07_human_in_the_loop.py` and `16_approval_decorator.py`, nothing asked for permission here — the run was destroyed mid-flight and recovered in place under its original `run_id`.
+
+---
+
+## 18_filesystem.py
+
+```
+=== Session 1 (user: alice) — record a durable fact ===
+
+╭──────────────────────────────────────────────────────────────────────────────╮
+│ I've recorded that you're benchmarking vector databases for a RAG pipeline   │
+│ and have chosen LanceDb for its embedded serverless operation.               │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+=== Session 2 (user: alice, new session) — recall from the file store ===
+
+╭──────────────────────────────────────────────────────────────────────────────╮
+│ You settled on LanceDb as the vector database because it runs embedded with  │
+│ no server.                                                                   │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+=== Session 3 (user: bob) — namespace isolation ===
+
+╭──────────────────────────────────────────────────────────────────────────────╮
+│ I have no note on which vector database was selected or the reasoning behind │
+│ it.                                                                          │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+=== The store, seen from outside the agent ===
+
+namespace 'notes/alice': 1 file(s), 110 bytes
+  - notes/project.md (110 bytes, version 1)
+namespace 'notes/bob': 0 file(s), 0 bytes
+
+Contents of alice's notes/project.md:
+Benchmarking vector databases for a RAG pipeline. Settled on LanceDb because it runs embedded with no server.
+```
+
+> Session 2 uses a different `session_id` with no conversation history, so the recalled answer can only have come from the file store — that is what makes `FileSystem` different from the transcripts in `10_storage.py` and the ephemeral dict in `13_session_state.py`. Session 3 is the same agent and the same SQLite file, but `notes/{user_id}` resolves to an empty namespace for `bob`.
+
+---
+
+## 19_eval_suite.py
+
+```
+=== Running eval suite ===
+
+[PASS] converts 100 EUR correctly
+  tags:         currency
+  tools called: ['get_exchange_rate']
+  score:        1.0 (passed=True)
+  output:       {"currency":"EUR","usd_amount":109.0}
+  duration:     2.26s
+[PASS] looks the rate up instead of guessing
+  tags:         currency, reliability
+  tools called: ['get_exchange_rate']
+  score:        1.0 (passed=True)
+  output:       {"currency":"GBP","usd_amount":63.5}
+  duration:     2.16s
+
+Suite: PASS — 2/2 cases passed
+```
+
+> Both scorers are deterministic: `CodeScorer` compares the typed `usd_amount` field against `expected=109.0`, and `ToolCallScorer` asserts that `get_exchange_rate` really executed with `currency="GBP"`. No judge model runs, so the suite costs only the two agent runs.

--- a/agno/README.md
+++ b/agno/README.md
@@ -2,7 +2,7 @@
 
 - Repo: https://github.com/agno-agi/agno
 - Documentation: https://docs.agno.com
-- Version: **2.6.18**
+- Version: **2.8.7**
 
 ## Agno Examples
 
@@ -43,7 +43,7 @@ cp .env.example .env
 
 | # | File | Feature | Description |
 |---|------|---------|-------------|
-| 00 | `00_basic_agent.py` | Agents | Basic agent with instructions and formatted output |
+| 00 | `00_hello_world.py` | Agents | Basic agent with instructions and formatted output |
 | 01 | `01_agent_with_tools.py` | Tools | Custom tools with `@tool` decorator |
 | 02 | `02_async_agent.py` | Async | Async agent runs with `arun()` and `asyncio.gather` |
 | 03 | `03_streaming.py` | Streaming | Token-by-token streaming with `RunOutputEvent` |
@@ -60,13 +60,19 @@ cp .env.example .env
 | 14 | `14_mcp_tools.py` | MCP Tools | External tool servers via Model Context Protocol |
 | 15 | `15_hooks.py` | Hooks | Pre-hooks and post-hooks for logging and transforms |
 | 16 | `16_approval_decorator.py` | Approval | `@approval` decorator for tool-level HITL gating |
+| 17 | `17_checkpointing.py` | Checkpointing | Crash recovery with `checkpoint="tool-batch"`, `continue_run()` and `fork_session()` |
+| 18 | `18_filesystem.py` | FileSystem | Durable per-user file store with `agno.fs.FileSystem` and `fs.tools()` |
+| 19 | `19_eval_suite.py` | Evals | `Case` + `run_cases()` graded by `CodeScorer` and `ToolCallScorer` |
 
 ### Running examples
 
 Run any example directly:
 
 ```bash
-python 00_basic_agent.py
+python 00_hello_world.py
+python 17_checkpointing.py
+python 18_filesystem.py
+python 19_eval_suite.py
 ```
 
 > **Note:** Example `14_mcp_tools.py` requires Node.js (npx) installed for the MCP filesystem server.

--- a/agno/pyproject.toml
+++ b/agno/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Agno framework examples"
 requires-python = ">=3.12"
 dependencies = [
-    "agno>=2.5.0",
+    "agno>=2.8.2",
     "ddgs",
     "fastapi",
     "lancedb",

--- a/agno/uv.lock
+++ b/agno/uv.lock
@@ -12,26 +12,23 @@ resolution-markers = [
 
 [[package]]
 name = "agno"
-version = "2.6.18"
+version = "2.8.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "agnoctl" },
     { name = "docstring-parser" },
-    { name = "gitpython" },
     { name = "h11" },
     { name = "httpx", extra = ["http2"] },
     { name = "packaging" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
-    { name = "python-dotenv" },
-    { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "rich" },
-    { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/82/442e6377753bfc8f532107d20776aebcfd6f4d077b9d7f67782e0adb3cf4/agno-2.6.18.tar.gz", hash = "sha256:2a10f3aec66afe7ed4fcab655a35da3f190bc1e638dcaf41d425878e5cde1946", size = 2155365, upload-time = "2026-06-18T20:37:36.458Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/3e/8ccb64e7468edfa893e10256bcff362f0c0de995ccbf6672ac94f1d3860a/agno-2.8.7.tar.gz", hash = "sha256:d49396a2062ee6994ca82695b9bd1e1b95667fec432c544afa38133e564bf090", size = 2558062, upload-time = "2026-08-05T14:45:46.26Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/e4/d1e895cb85b8e675f68bda54e52f419acaf8a2fff935f118f54b9c1fd774/agno-2.6.18-py3-none-any.whl", hash = "sha256:4e4ac7d5f74afefda51c998121d3fa7b8cc591e96ba7ebd4f54a0328a9072c06", size = 2543984, upload-time = "2026-06-18T20:37:34.136Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/70/dd751ae630be7eff6835cb7659fc3d53c19503da060635f1a0af56c1843b/agno-2.8.7-py3-none-any.whl", hash = "sha256:6a2763eb469163f7b79ab1da6ca2f22d8619f6b9d614574f975d9c12bb4323ea", size = 2986771, upload-time = "2026-08-05T14:45:43.508Z" },
 ]
 
 [[package]]
@@ -55,7 +52,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agno", specifier = ">=2.5.0" },
+    { name = "agno", specifier = ">=2.8.2" },
     { name = "ddgs" },
     { name = "fastapi" },
     { name = "lancedb" },
@@ -67,6 +64,20 @@ requires-dist = [
     { name = "rich" },
     { name = "sqlalchemy" },
     { name = "tantivy" },
+]
+
+[[package]]
+name = "agnoctl"
+version = "0.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "rich" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/a1/eafa5a39b2d97b1859d5179935388e8770cba4ed417b386d672e509e4777/agnoctl-0.1.3.tar.gz", hash = "sha256:6fce1d2482b1f2e0a3d14b0a7c12fbd49d8df4f0bf0a4fd9fd91753cbff5efdc", size = 92991, upload-time = "2026-07-17T09:22:58.475Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/74/fdeb7c57543add6d10b68ffbfc16dc932eae72042064ed2afefdf4395b1b/agnoctl-0.1.3-py3-none-any.whl", hash = "sha256:94e1570cf2673ace2d7fa347b51c5fb2416d6f993a0a24b4fca71b04b15e72dd", size = 73695, upload-time = "2026-07-17T09:22:56.923Z" },
 ]
 
 [[package]]
@@ -307,30 +318,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e7/7b/f8e0211e9380f7195ba3f3d40c292594fd81ba8ec4629e3854c353aaca45/fastapi-0.135.1.tar.gz", hash = "sha256:d04115b508d936d254cea545b7312ecaa58a7b3a0f84952535b4c9afae7668cd", size = 394962, upload-time = "2026-03-01T18:18:29.369Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/72/42e900510195b23a56bde950d26a51f8b723846bfcaa0286e90287f0422b/fastapi-0.135.1-py3-none-any.whl", hash = "sha256:46e2fc5745924b7c840f71ddd277382af29ce1cdb7d5eab5bf697e3fb9999c9e", size = 116999, upload-time = "2026-03-01T18:18:30.831Z" },
-]
-
-[[package]]
-name = "gitdb"
-version = "4.0.12"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "smmap" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684, upload-time = "2025-01-02T07:20:46.413Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf", size = 62794, upload-time = "2025-01-02T07:20:43.624Z" },
-]
-
-[[package]]
-name = "gitpython"
-version = "3.1.46"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "gitdb" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/df/b5/59d16470a1f0dfe8c793f9ef56fd3826093fc52b3bd96d6b9d6c26c7e27b/gitpython-3.1.46.tar.gz", hash = "sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f", size = 215371, upload-time = "2026-01-01T15:37:32.073Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/09/e21df6aef1e1ffc0c816f0522ddc3f6dcded766c3261813131c78a704470/gitpython-3.1.46-py3-none-any.whl", hash = "sha256:79812ed143d9d25b6d176a10bb511de0f9c67b1fa641d82097b0ab90398a2058", size = 208620, upload-time = "2026-01-01T15:37:30.574Z" },
 ]
 
 [[package]]
@@ -1249,15 +1236,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
-]
-
-[[package]]
-name = "smmap"
-version = "5.0.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1f/ea/49c993d6dfdd7338c9b1000a0f36817ed7ec84577ae2e52f890d1a4ff909/smmap-5.0.3.tar.gz", hash = "sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c", size = 22506, upload-time = "2026-03-09T03:43:26.1Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl", hash = "sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f", size = 24390, upload-time = "2026-03-09T03:43:24.361Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- `agno` 2.6.18 → 2.8.7 (18 releases), and 3 new examples covering the range's net-new client-side packages: 17 examples → 20.
- No existing example broke. All three declared breaking changes in the range land in `agno.eval` internals, `AgentOS` and `ScavioTools` — none of which any example imports.

## What changed

### Package upgrade

- `agno` `2.6.18` → `2.8.7`
- `agnoctl` `0.1.3` added — a new transitive dependency of `agno` 2.8.x, not a direct dependency here.
- `agno` dropped `gitpython`, `python-multipart` and `typer` as direct requirements; `python-dotenv` stays pinned in `pyproject.toml` because every example calls `load_dotenv()`.
- Floor raised `agno>=2.5.0` → `agno>=2.8.2`: `18_filesystem.py` imports `agno.fs`, which does not exist before 2.8.2, so a non-locked install below that floor fails at import.

### Existing examples fixed

| File | Change |
|------|--------|
| `11_guardrails.py` | `InputCheckError` imported from the public `agno.exceptions` instead of the private `agno.agent._hooks` (still re-exported at 2.8.7, but not the supported path) |
| `16_approval_decorator.py` | Removed unused `ApprovalType` import |
| `README.md` / `OUTPUTS.md` | Examples table and output heading referenced `00_basic_agent.py`; the file on disk is `00_hello_world.py` |

### New examples added

| # | File | Feature | Docs |
|---|------|---------|------|
| 17 | `17_checkpointing.py` | `Agent(checkpoint="tool-batch")`, `continue_run(run_id=...)`, `fork_session()` | [crash recovery](https://docs.agno.com/examples/agents/checkpointing/crash-recovery) |
| 18 | `18_filesystem.py` | `agno.fs.FileSystem` + `fs.tools()` + `fs.instructions()`, `SqliteDb` backend, templated `notes/{user_id}` namespace | [filesystem overview](https://docs.agno.com/filesystem/overview) |
| 19 | `19_eval_suite.py` | `agno.eval.suite.Case` + `run_cases()`, graded by `CodeScorer` and `ToolCallScorer` | [evals suite](https://docs.agno.com/evals/suite/overview) |

No new dependencies: all three need only `agno`, stdlib and `pydantic`.

### Key changes in this range

- **Checkpointing** (v2.6.19) — `checkpoint="tool-batch"` writes run state after each model turn, so a run killed mid-flight resumes in place under its original `run_id`. The only param added to `Agent.__init__`/`Team.__init__` in the whole range.
- **`agno.fs`** (v2.8.2) — durable, quota-capped, per-namespace file store for the agent's own notes; a third kind of state alongside session transcripts and session state.
- **`agno.eval.suite`** (v2.7.0) + **`agno.scorer`** (v2.8.0) — declarative eval cases with deterministic in-process scorers and a CI-stable `to_dict()` payload.
- **`agno.environments`** (v2.8.0) — pass@k rollouts. Deliberately not added: it costs k × tasks LLM calls per run and has no docs page yet (cookbook only).

### Notes

- `17_checkpointing.py` simulates the crash with an exception derived from `BaseException` rather than SIGKILLing a subprocess (which is what the docs example does). `Exception` is caught by Agno's tool error handling and fed back to the model; `BaseException` tears the run down, which is the behaviour a crash needs, and keeps the example a single self-contained file with no `multiprocessing`.
- Both new SQLite databases are written to `/tmp`, matching `10_storage.py` and `13_session_state.py`. Nothing new lands in `res/`.
- `OUTPUTS.md` sections for `11` and `16` were refreshed from the new runs; the diff is cosmetic (a line-wrapped `CheckTrigger` suffix, and LLM wording). Every untouched section is byte-identical.

## Configuration

- Examples use **OpenAI** (`gpt-4o-mini`) via `settings.py`
- Dependencies: `agno>=2.8.2`, `ddgs`, `fastapi`, `lancedb`, `mcp`, `openai`, `pydantic`, `pydantic-settings`, `python-dotenv`, `rich`, `sqlalchemy`, `tantivy`
- Managed with `uv`

## Testing

- `uv sync --frozen`: clean, lock consistent with `pyproject.toml`.
- `uv run python -m py_compile *.py`: 20/20 files compile.
- Import resolution: every import statement in all 20 examples executed against 2.8.7 — 20/20 resolve (py_compile does not import, so this is a separate gate).
- Live-run against the OpenAI API: 5 files — `11_guardrails.py`, `16_approval_decorator.py`, `17_checkpointing.py`, `18_filesystem.py`, `19_eval_suite.py`. All exit 0 with output demonstrating the feature (`19` gates on `SuiteResult.status`, and it reports PASS 2/2).
- The other 15 examples were not live-run: they are untouched by this PR and the research pass resolved every `agno.*` symbol they use against the 2.8.7 tree.
