### PR TITLE
feat(langgraph): upgrade to v1.2.10 and add 4 new examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ This repository provides a comprehensive, hands-on comparison of modern AI agent
           <img src="res/langgraph-text.svg" alt="LangGraph" width="100" style="vertical-align: middle;">
         </picture>
       </td>
-      <td><code>1.2.6</code></td>
+      <td><code>1.2.10</code></td>
       <td>
           <a href="https://langchain-ai.github.io/langgraph/">
             <picture>

--- a/langgraph/23_runtime_context.py
+++ b/langgraph/23_runtime_context.py
@@ -1,0 +1,144 @@
+from dataclasses import dataclass
+
+from dotenv import load_dotenv
+
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage, SystemMessage
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.func import entrypoint
+from langgraph.graph import StateGraph, START, END
+from langgraph.runtime import Runtime
+from langgraph.store.memory import InMemoryStore
+from typing_extensions import TypedDict
+
+from settings import settings
+
+load_dotenv()
+
+"""
+-----------------------------------------------------------------------
+In this example, we explore LangGraph with the following features:
+- Declaring run-scoped dependencies with StateGraph(..., context_schema=...)
+- Injecting Runtime[ContextSchema] as a second node argument
+- Reading runtime.context, runtime.store and runtime.stream_writer in a node
+- Passing per-run values with graph.invoke(..., context=...)
+- runtime.previous for the functional API's per-thread carry-over value
+
+Runtime context is the LangGraph 1.0 replacement for smuggling
+configuration (user id, tenant, locale, db handles) through graph state.
+Context is declared once as a schema, supplied per run, and reaches every
+node via a typed Runtime object — it never becomes part of the state, so
+it is never checkpointed and never merged by a reducer.
+
+For more details, visit:
+https://docs.langchain.com/oss/python/langgraph/use-graph-api#add-runtime-configuration
+-----------------------------------------------------------------------
+"""
+
+llm = ChatOpenAI(model=settings.OPENAI_MODEL_NAME)
+
+
+# --- 1. Declare the run-scoped context schema ---
+@dataclass
+class RequestContext:
+    """Per-run dependencies. Not state: never checkpointed, never reduced."""
+
+    user_id: str
+    locale: str
+    tone: str
+
+
+class ReplyState(TypedDict, total=False):
+    question: str
+    profile: str
+    reply: str
+
+
+# --- 2. Seed a store with data the nodes will look up by context ---
+store = InMemoryStore()
+store.put(("profiles",), "u-100", {"name": "Alice", "plan": "enterprise"})
+store.put(("profiles",), "u-200", {"name": "Bruno", "plan": "free"})
+
+
+# --- 3. Nodes take (state, runtime) — runtime carries context/store/stream_writer ---
+def load_profile(state: ReplyState, runtime: Runtime[RequestContext]) -> dict:
+    """Resolve the caller's profile from the store using runtime.context."""
+    user_id = runtime.context.user_id
+
+    # runtime.stream_writer emits to stream_mode="custom" without touching state
+    runtime.stream_writer({"step": "load_profile", "user_id": user_id})
+
+    record = runtime.store.get(("profiles",), user_id)
+    profile = f"{record.value['name']} ({record.value['plan']} plan)"
+    return {"profile": profile}
+
+
+def answer(state: ReplyState, runtime: Runtime[RequestContext]) -> dict:
+    """Shape the LLM call from runtime.context — no context value is in state."""
+    ctx = runtime.context
+    runtime.stream_writer({"step": "answer", "tone": ctx.tone})
+
+    system = (
+        f"You are a support agent. The customer you are helping is {state['profile']}. "
+        f"Reply in {ctx.locale} using a {ctx.tone} tone, in exactly one sentence."
+    )
+    response = llm.invoke(
+        [SystemMessage(content=system), HumanMessage(content=state["question"])]
+    )
+    return {"reply": response.content}
+
+
+# --- 4. Build the graph, binding the context schema and the store ---
+builder = StateGraph(ReplyState, context_schema=RequestContext)
+builder.add_node("load_profile", load_profile)
+builder.add_node("answer", answer)
+builder.add_edge(START, "load_profile")
+builder.add_edge("load_profile", "answer")
+builder.add_edge("answer", END)
+
+graph = builder.compile(store=store)
+
+# --- 5. Same input state, different context per run ---
+print("=== Same input, two different runtime contexts ===\n")
+
+question = {"question": "Can I export my data?"}
+
+for ctx in (
+    RequestContext(user_id="u-100", locale="English", tone="formal"),
+    # A plain dict is accepted too — it is coerced into the context schema
+    {"user_id": "u-200", "locale": "Portuguese", "tone": "playful"},
+):
+    result = graph.invoke(question, context=ctx)
+    print(f"  context ....... {ctx}")
+    print(f"  profile ....... {result['profile']}")
+    print(f"  reply ......... {result['reply']}")
+    print(f"  state keys .... {sorted(result)}  <- no user_id/locale/tone in state")
+    print()
+
+# --- 6. runtime.stream_writer feeds stream_mode="custom" ---
+print("=== Custom stream written from runtime.stream_writer ===\n")
+
+for chunk in graph.stream(
+    question,
+    stream_mode="custom",
+    context=RequestContext(user_id="u-100", locale="English", tone="terse"),
+):
+    print(f"  {chunk}")
+print()
+
+# --- 7. runtime.previous: functional-API-only carry-over across runs ---
+print("=== runtime.previous (functional API, needs a checkpointer) ===\n")
+
+
+@entrypoint(checkpointer=InMemorySaver())
+def running_total(amount: int, runtime: Runtime) -> entrypoint.final:
+    """Return the running total while saving it for the next run on this thread."""
+    previous = runtime.previous or 0
+    total = previous + amount
+    return entrypoint.final(value={"previous": previous, "total": total}, save=total)
+
+
+config = {"configurable": {"thread_id": "totals-1"}}
+for amount in (10, 5, 2):
+    step = running_total.invoke(amount, config=config)
+    print(f"  +{amount:<3} previous={step['previous']:<3} total={step['total']}")

--- a/langgraph/24_overwrite_and_deferred_nodes.py
+++ b/langgraph/24_overwrite_and_deferred_nodes.py
@@ -1,0 +1,158 @@
+import operator
+from typing import Annotated
+
+from dotenv import load_dotenv
+
+from langgraph.errors import InvalidUpdateError
+from langgraph.graph import StateGraph, START, END
+from langgraph.types import Overwrite
+from typing_extensions import TypedDict
+
+from settings import settings
+
+load_dotenv()
+
+"""
+-----------------------------------------------------------------------
+In this example, we explore LangGraph with the following features:
+- Bypassing a channel's reducer with Overwrite(value=...)
+- The JSON-safe {"__overwrite__": ...} form of the same instruction
+- InvalidUpdateError when two parallel nodes Overwrite the same channel
+- Deferring a fan-in node with add_node(..., defer=True)
+
+A reducer such as operator.add is a one-way street: every node that writes
+to the channel appends. Overwrite is the escape hatch — it replaces the
+channel value instead of merging into it, which is how a compaction or
+summarisation node discards history. defer=True solves the complementary
+problem on the control-flow side: a fan-in node whose branches have
+different lengths would otherwise run once per super-step in which any
+branch arrives, instead of once at the end with everything collected.
+
+For more details, visit:
+https://docs.langchain.com/oss/python/langgraph/use-graph-api#bypass-reducers-with-overwrite
+-----------------------------------------------------------------------
+"""
+
+
+# --- 1. State whose channel accumulates via a reducer ---
+class NotesState(TypedDict):
+    notes: Annotated[list[str], operator.add]
+
+
+def gather(state: NotesState) -> dict:
+    """Normal update: goes through operator.add, so it appends."""
+    return {"notes": ["gathered-a", "gathered-b"]}
+
+
+def compact(state: NotesState) -> dict:
+    """Overwrite update: bypasses operator.add and replaces the channel."""
+    summary = f"summary of {len(state['notes'])} notes"
+    return {"notes": Overwrite([summary])}
+
+
+builder = StateGraph(NotesState)
+builder.add_node("gather", gather)
+builder.add_node("compact", compact)
+builder.add_edge(START, "gather")
+builder.add_edge("gather", "compact")
+builder.add_edge("compact", END)
+graph = builder.compile()
+
+# --- 2. Watch the channel across super-steps ---
+print("=== Reducer append, then Overwrite ===\n")
+
+for snapshot in graph.stream({"notes": ["seed"]}, stream_mode="values"):
+    print(f"  notes = {snapshot['notes']}")
+print("\n  Without Overwrite the last line would have been")
+print("  ['seed', 'gathered-a', 'gathered-b', 'summary of 3 notes']\n")
+
+
+# --- 3. The JSON-safe form: {"__overwrite__": value} ---
+def compact_json_form(state: NotesState) -> dict:
+    """Same semantics as Overwrite, survives a JSON round-trip through a server."""
+    return {"notes": {"__overwrite__": ["summary via JSON form"]}}
+
+
+json_builder = StateGraph(NotesState)
+json_builder.add_node("compact_json_form", compact_json_form)
+json_builder.add_edge(START, "compact_json_form")
+json_builder.add_edge("compact_json_form", END)
+
+print("=== JSON form of Overwrite ===\n")
+result = json_builder.compile().invoke({"notes": ["seed", "kept-nothing"]})
+print(f"  notes = {result['notes']}\n")
+
+
+# --- 4. The trap: two parallel Overwrites on one channel ---
+def compact_left(state: NotesState) -> dict:
+    return {"notes": Overwrite(["from-left"])}
+
+
+def compact_right(state: NotesState) -> dict:
+    return {"notes": Overwrite(["from-right"])}
+
+
+parallel_builder = StateGraph(NotesState)
+parallel_builder.add_node("compact_left", compact_left)
+parallel_builder.add_node("compact_right", compact_right)
+parallel_builder.add_edge(START, "compact_left")
+parallel_builder.add_edge(START, "compact_right")
+parallel_builder.add_edge("compact_left", END)
+parallel_builder.add_edge("compact_right", END)
+
+print("=== Two parallel Overwrites on the same channel ===\n")
+try:
+    parallel_builder.compile().invoke({"notes": ["seed"]})
+except InvalidUpdateError as exc:
+    print(f"  InvalidUpdateError: {str(exc).splitlines()[0]}")
+print("  There is no reducer left to merge them, so LangGraph refuses to pick.\n")
+
+
+# --- 5. Uneven branches: with and without defer ---
+class PipelineState(TypedDict):
+    log: Annotated[list[str], operator.add]
+
+
+def make_step(name: str):
+    def step(state: PipelineState) -> dict:
+        return {"log": [name]}
+
+    return step
+
+
+def build_pipeline(defer: bool):
+    """Long branch: extract -> enrich -> score. Short branch: lookup. Both fan into report."""
+    calls: list[int] = []
+
+    def report(state: PipelineState) -> dict:
+        calls.append(len(state["log"]))
+        return {"log": [f"report(saw {len(state['log'])})"]}
+
+    b = StateGraph(PipelineState)
+    for name in ("extract", "enrich", "score", "lookup"):
+        b.add_node(name, make_step(name))
+    b.add_node("report", report, defer=defer)
+
+    b.add_edge(START, "extract")
+    b.add_edge("extract", "enrich")
+    b.add_edge("enrich", "score")
+    b.add_edge("score", "report")
+    b.add_edge(START, "lookup")
+    b.add_edge("lookup", "report")
+    b.add_edge("report", END)
+    return b.compile(), calls
+
+
+print("=== Fan-in across uneven branches ===\n")
+
+for defer in (False, True):
+    pipeline, calls = build_pipeline(defer)
+    final = pipeline.invoke({"log": []})
+    print(f"  defer={defer}")
+    print(f"    report ran {len(calls)}x, log entries visible per call: {calls}")
+    print(f"    final log = {final['log']}")
+    print()
+
+print("  Without defer, 'lookup' finishes in super-step 1 and fires 'report'")
+print("  before the long branch is done. defer=True holds it until the run")
+print("  is about to end, so it runs once with every branch collected.")

--- a/langgraph/25_timeouts_and_durability.py
+++ b/langgraph/25_timeouts_and_durability.py
@@ -1,0 +1,145 @@
+import asyncio
+
+from dotenv import load_dotenv
+
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.errors import NodeTimeoutError
+from langgraph.graph import StateGraph, START, END
+from langgraph.types import RetryPolicy, TimeoutPolicy
+from typing_extensions import TypedDict
+
+from settings import settings
+
+load_dotenv()
+
+"""
+-----------------------------------------------------------------------
+In this example, we explore LangGraph with the following features:
+- Per-node wall-clock timeouts with add_node(..., timeout=seconds)
+- TimeoutPolicy(run_timeout=..., idle_timeout=...) for finer control
+- Catching NodeTimeoutError, and combining a timeout with a RetryPolicy
+- The async-only constraint: timeout= on a sync node fails at compile time
+- Checkpoint durability modes: durability="sync" / "async" / "exit"
+
+Timeouts bound how long a single node attempt may run; the resulting
+NodeTimeoutError then flows into the node's retry policy, so a flaky
+dependency can be capped and retried rather than hanging the graph.
+Durability controls how often the checkpointer is written: "sync" and
+"async" persist every super-step (resumable mid-run), while "exit" writes
+only once at the end (fastest, but a crash loses the whole run).
+
+For more details, visit:
+https://docs.langchain.com/oss/python/langgraph/fault-tolerance#timeouts
+-----------------------------------------------------------------------
+"""
+
+
+class State(TypedDict, total=False):
+    label: str
+    attempts: int
+    result: str
+
+
+# --- 1. Timeouts are async-only — a sync node raises at compile time ---
+print("=== Constraint: timeout= requires an async node ===\n")
+
+
+def sync_node(state: State) -> dict:
+    return {"result": "done"}
+
+
+sync_builder = StateGraph(State)
+sync_builder.add_node("sync_node", sync_node, timeout=1.0)  # accepted here...
+sync_builder.add_edge(START, "sync_node")
+sync_builder.add_edge("sync_node", END)
+try:
+    sync_builder.compile()  # ...and rejected here
+except ValueError as exc:
+    print(f"  ValueError at compile(): {exc}\n")
+
+
+# --- 2. An async node that overruns its timeout ---
+async def slow_fetch(state: State) -> dict:
+    """Simulate a dependency that takes longer than we are willing to wait."""
+    await asyncio.sleep(2.0)
+    return {"result": "fetched"}
+
+
+timeout_builder = StateGraph(State)
+timeout_builder.add_node("slow_fetch", slow_fetch, timeout=0.3)
+timeout_builder.add_edge(START, "slow_fetch")
+timeout_builder.add_edge("slow_fetch", END)
+timeout_graph = timeout_builder.compile()
+
+
+# --- 3. A timeout with a retry policy: the second attempt is fast enough ---
+attempts = {"count": 0}
+
+
+async def flaky_fetch(state: State) -> dict:
+    """First attempt overruns the timeout, later attempts return immediately."""
+    attempts["count"] += 1
+    if attempts["count"] == 1:
+        await asyncio.sleep(2.0)
+    return {
+        "result": f"fetched on attempt {attempts['count']}",
+        "attempts": attempts["count"],
+    }
+
+
+retry_builder = StateGraph(State)
+retry_builder.add_node(
+    "flaky_fetch",
+    flaky_fetch,
+    timeout=TimeoutPolicy(run_timeout=0.3, idle_timeout=0.2),
+    retry_policy=RetryPolicy(max_attempts=3, retry_on=(NodeTimeoutError,)),
+)
+retry_builder.add_edge(START, "flaky_fetch")
+retry_builder.add_edge("flaky_fetch", END)
+retry_graph = retry_builder.compile()
+
+
+# --- 4. Durability modes: count the checkpoints each one leaves behind ---
+def step(state: State) -> dict:
+    return {"attempts": state.get("attempts", 0) + 1}
+
+
+durability_builder = StateGraph(State)
+durability_builder.add_node("first", step)
+durability_builder.add_node("second", step)
+durability_builder.add_node("third", step)
+durability_builder.add_edge(START, "first")
+durability_builder.add_edge("first", "second")
+durability_builder.add_edge("second", "third")
+durability_builder.add_edge("third", END)
+
+
+async def main() -> None:
+    print("=== Async node exceeding timeout=0.3 ===\n")
+    try:
+        await timeout_graph.ainvoke({"label": "slow"})
+    except NodeTimeoutError as exc:
+        print(f"  NodeTimeoutError: {exc}\n")
+
+    print("=== TimeoutPolicy + RetryPolicy(retry_on=NodeTimeoutError) ===\n")
+    policy = TimeoutPolicy(run_timeout=0.3, idle_timeout=0.2)
+    print(f"  run_timeout={policy.run_timeout}s  idle_timeout={policy.idle_timeout}s")
+    result = await retry_graph.ainvoke({"label": "flaky"})
+    print(f"  attempt 1 timed out, then: {result['result']}\n")
+
+    print("=== Durability modes over a 3-node run ===\n")
+    for mode in ("sync", "async", "exit"):
+        graph = durability_builder.compile(checkpointer=InMemorySaver())
+        config = {"configurable": {"thread_id": f"thread-{mode}"}}
+        async for _ in graph.astream({"attempts": 0}, config=config, durability=mode):
+            pass
+        history = [snapshot async for snapshot in graph.aget_state_history(config)]
+        print(f"  durability={mode:<6} -> {len(history)} checkpoint(s) persisted")
+    print()
+    print('  "sync"/"async" write every super-step, so the run is resumable from')
+    print('  the last completed node. "exit" writes once at the end — cheapest,')
+    print("  but an interrupted run has nothing to resume from.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/langgraph/26_event_streaming_v3.py
+++ b/langgraph/26_event_streaming_v3.py
@@ -1,0 +1,139 @@
+from dotenv import load_dotenv
+
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage, SystemMessage
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import StateGraph, MessagesState, START, END
+from langgraph.stream import UpdatesTransformer
+from langgraph.types import interrupt
+from typing_extensions import TypedDict
+
+from settings import settings
+
+load_dotenv()
+
+"""
+-----------------------------------------------------------------------
+In this example, we explore LangGraph with the following features:
+- graph.stream_events(..., version="v3") returning a GraphRunStream
+- Typed native projections: .messages, .values, .subgraphs, .output
+- Per-message projections: message.text deltas and message.output
+- .interrupted / .interrupts to detect a paused run
+- Opting extra projections in with transformers=[UpdatesTransformer]
+
+The v3 event protocol replaces stream_mode tuples with a run handle whose
+typed projections you iterate: run.messages yields one stream per LLM call,
+run.values yields state snapshots, run.output drives the run to completion.
+Iterating a projection is what pumps the graph — there is no background
+thread — so each projection is single-consumer and a run is driven once.
+The v3 protocol is still marked experimental, so running this emits a
+LangChainBetaWarning on stderr.
+
+For more details, visit:
+https://docs.langchain.com/oss/python/langgraph/event-streaming
+-----------------------------------------------------------------------
+"""
+
+llm = ChatOpenAI(model=settings.OPENAI_MODEL_NAME)
+
+SYSTEM = SystemMessage(content="You are terse. Answer in one short sentence.")
+
+
+# --- 1. A minimal chat graph to stream from ---
+def chat(state: MessagesState) -> dict:
+    return {"messages": [llm.invoke([SYSTEM] + state["messages"])]}
+
+
+builder = StateGraph(MessagesState)
+builder.add_node("chat", chat)
+builder.add_edge(START, "chat")
+builder.add_edge("chat", END)
+graph = builder.compile()
+
+
+def ask(text: str) -> dict:
+    return {"messages": [HumanMessage(content=text)]}
+
+
+# --- 2. run.messages: one stream handle per LLM call, with token deltas ---
+print("=== run.messages -> message.text deltas ===\n")
+
+run = graph.stream_events(ask("Name the largest planet."), version="v3")
+for message in run.messages:
+    print(f"  node={message.node}")
+    print("  deltas: ", end="", flush=True)
+    for delta in message.text:
+        print(f"{delta!r} ", end="", flush=True)
+    print()
+    print(f"  assembled: {str(message.text)}")
+    print(f"  tokens:    {message.output.usage_metadata['total_tokens']}")
+print()
+
+# --- 3. run.values: state snapshots, then run.output for the final state ---
+print("=== run.values -> snapshots, run.output -> final state ===\n")
+
+run = graph.stream_events(ask("Name the smallest planet."), version="v3")
+for step, snapshot in enumerate(run.values):
+    print(f"  snapshot {step}: {len(snapshot['messages'])} message(s)")
+print(f"  run.output keys: {list(run.output)}")
+print(f"  final answer:    {run.output['messages'][-1].text}\n")
+
+# --- 4. transformers=[...]: opt in to a non-native projection ---
+print("=== transformers=[UpdatesTransformer] -> run.extensions['updates'] ===\n")
+
+run = graph.stream_events(
+    ask("Name the hottest planet."),
+    version="v3",
+    transformers=[UpdatesTransformer],
+)
+print(f"  projections available: {list(run.extensions)}")
+for update in run.extensions["updates"]:
+    for node, payload in update.items():
+        print(f"  update from '{node}': {payload['messages'][-1].text}")
+print()
+
+# --- 5. run.subgraphs: nested runs get their own handle ---
+print("=== run.subgraphs -> nested run handles ===\n")
+
+inner_builder = StateGraph(MessagesState)
+inner_builder.add_node("inner_chat", chat)
+inner_builder.add_edge(START, "inner_chat")
+inner_builder.add_edge("inner_chat", END)
+
+outer_builder = StateGraph(MessagesState)
+outer_builder.add_node("delegate", inner_builder.compile())
+outer_builder.add_edge(START, "delegate")
+outer_builder.add_edge("delegate", END)
+outer = outer_builder.compile()
+
+run = outer.stream_events(ask("Name the reddest planet."), version="v3")
+for subgraph in run.subgraphs:
+    print(f"  subgraph '{subgraph.graph_name}' at path {subgraph.path}")
+    for message in subgraph.messages:
+        print(f"    {str(message.text)}")
+print()
+
+
+# --- 6. run.interrupted / run.interrupts: a paused run ---
+class ApprovalState(TypedDict, total=False):
+    decision: str
+
+
+def request_approval(state: ApprovalState) -> dict:
+    return {"decision": interrupt({"question": "Deploy to production?"})}
+
+
+approval_builder = StateGraph(ApprovalState)
+approval_builder.add_node("request_approval", request_approval)
+approval_builder.add_edge(START, "request_approval")
+approval_builder.add_edge("request_approval", END)
+approval_graph = approval_builder.compile(checkpointer=InMemorySaver())
+
+print("=== run.interrupted / run.interrupts ===\n")
+
+run = approval_graph.stream_events(
+    {}, {"configurable": {"thread_id": "approval-1"}}, version="v3"
+)
+print(f"  interrupted: {run.interrupted}")
+for pause in run.interrupts:
+    print(f"  waiting on:  {pause.value}")

--- a/langgraph/OUTPUTS.md
+++ b/langgraph/OUTPUTS.md
@@ -635,3 +635,134 @@ Saved in checkpoint: The report on Artificial Intelligence Ethics examines the m
 ```
 
 > Demonstrates node-level error handlers and cache policies (new in v1.2.0) — graceful degradation when nodes fail, and TTL-based caching for expensive computations.
+
+## 23_runtime_context.py
+
+```
+=== Same input, two different runtime contexts ===
+
+  context ....... RequestContext(user_id='u-100', locale='English', tone='formal')
+  profile ....... Alice (enterprise plan)
+  reply ......... Yes, as an enterprise plan user, you have the ability to export your data at any time.
+  state keys .... ['profile', 'question', 'reply']  <- no user_id/locale/tone in state
+
+  context ....... {'user_id': 'u-200', 'locale': 'Portuguese', 'tone': 'playful'}
+  profile ....... Bruno (free plan)
+  reply ......... Oi Bruno! No plano gratuito, você pode sonhar em exportar seus dados, mas por enquanto, vamos aproveitar juntos tudo o que temos por aqui! 🌟
+  state keys .... ['profile', 'question', 'reply']  <- no user_id/locale/tone in state
+
+=== Custom stream written from runtime.stream_writer ===
+
+  {'step': 'load_profile', 'user_id': 'u-100'}
+  {'step': 'answer', 'tone': 'terse'}
+
+=== runtime.previous (functional API, needs a checkpointer) ===
+
+  +10  previous=0   total=10
+  +5   previous=10  total=15
+  +2   previous=15  total=17
+```
+
+> The two runs share the identical input state `{"question": ...}` and differ only in the `context=` argument, yet the profile lookup and the reply language/tone both change — proof the context reached the nodes. The `state keys` line is the load-bearing part: `user_id`, `locale` and `tone` never appear in state, so they are never checkpointed and never passed through a reducer. `runtime.previous` is functional-API-only, hence the separate `@entrypoint` section.
+
+## 24_overwrite_and_deferred_nodes.py
+
+```
+=== Reducer append, then Overwrite ===
+
+  notes = ['seed']
+  notes = ['seed', 'gathered-a', 'gathered-b']
+  notes = ['summary of 3 notes']
+
+  Without Overwrite the last line would have been
+  ['seed', 'gathered-a', 'gathered-b', 'summary of 3 notes']
+
+=== JSON form of Overwrite ===
+
+  notes = ['summary via JSON form']
+
+=== Two parallel Overwrites on the same channel ===
+
+  InvalidUpdateError: Can receive only one Overwrite value per super-step.
+  There is no reducer left to merge them, so LangGraph refuses to pick.
+
+=== Fan-in across uneven branches ===
+
+  defer=False
+    report ran 2x, log entries visible per call: [2, 5]
+    final log = ['extract', 'lookup', 'enrich', 'report(saw 2)', 'score', 'report(saw 5)']
+
+  defer=True
+    report ran 1x, log entries visible per call: [4]
+    final log = ['extract', 'lookup', 'enrich', 'score', 'report(saw 4)']
+
+  Without defer, 'lookup' finishes in super-step 1 and fires 'report'
+  before the long branch is done. defer=True holds it until the run
+  is about to end, so it runs once with every branch collected.
+```
+
+> No LLM calls — fully deterministic. The `notes` progression shows `operator.add` appending, then `Overwrite` replacing the channel wholesale. `defer=False` runs the fan-in node twice (seeing 2 then 5 entries) because the short branch finishes first; `defer=True` runs it exactly once with all 4 entries.
+
+## 25_timeouts_and_durability.py
+
+```
+=== Constraint: timeout= requires an async node ===
+
+  ValueError at compile(): Node timeouts are only supported for async nodes because sync Python execution cannot be safely cancelled in-process. Node 'sync_node' is sync.
+
+=== Async node exceeding timeout=0.3 ===
+
+  NodeTimeoutError: Node 'slow_fetch' exceeded its run timeout of 0.300s (elapsed: 0.301s).
+
+=== TimeoutPolicy + RetryPolicy(retry_on=NodeTimeoutError) ===
+
+  run_timeout=0.3s  idle_timeout=0.2s
+  attempt 1 timed out, then: fetched on attempt 2
+
+=== Durability modes over a 3-node run ===
+
+  durability=sync   -> 5 checkpoint(s) persisted
+  durability=async  -> 5 checkpoint(s) persisted
+  durability=exit   -> 1 checkpoint(s) persisted
+
+  "sync"/"async" write every super-step, so the run is resumable from
+  the last completed node. "exit" writes once at the end — cheapest,
+  but an interrupted run has nothing to resume from.
+```
+
+> No LLM calls — timings come from `asyncio.sleep`. Note where the async-only constraint bites: `add_node(..., timeout=)` accepts a sync node silently and `compile()` is what raises. The checkpoint counts are the proof for durability: 5 for `"sync"`/`"async"` versus 1 for `"exit"`.
+
+## 26_event_streaming_v3.py
+
+```
+=== run.messages -> message.text deltas ===
+
+  node=chat
+  deltas: 'J' 'upiter' ' is' ' the' ' largest' ' planet' '.'
+  assembled: Jupiter is the largest planet.
+  tokens:    33
+
+=== run.values -> snapshots, run.output -> final state ===
+
+  snapshot 0: 1 message(s)
+  snapshot 1: 2 message(s)
+  run.output keys: ['messages']
+  final answer:    Mercury is the smallest planet.
+
+=== transformers=[UpdatesTransformer] -> run.extensions['updates'] ===
+
+  projections available: ['values', 'messages', 'lifecycle', 'subgraphs', 'updates']
+  update from 'chat': Venus is the hottest planet.
+
+=== run.subgraphs -> nested run handles ===
+
+  subgraph 'delegate' at path ('delegate:b19a8a75-996e-2a8b-298a-b6a365c7ef08',)
+    Mars is the reddest planet.
+
+=== run.interrupted / run.interrupts ===
+
+  interrupted: True
+  waiting on:  {'question': 'Deploy to production?'}
+```
+
+> Every section uses a fresh `stream_events(..., version="v3")` call: projections are single-consumer and iterating one is what pumps the graph, so a run cannot be replayed across projections. `values`/`messages`/`lifecycle`/`subgraphs` are always present; `updates` only appears because `transformers=[UpdatesTransformer]` opted it in. Running this also prints a `LangChainBetaWarning` on stderr — v3 is still marked experimental.

--- a/langgraph/README.md
+++ b/langgraph/README.md
@@ -2,6 +2,7 @@
 
 - Repo: https://github.com/langchain-ai/langgraph
 - Documentation: https://docs.langchain.com/oss/python/langgraph/overview
+- Version: **1.2.10**
 
 LangGraph is a framework from LangChain for building stateful, multi-actor agents as graphs. Nodes are functions, edges define control flow, and built-in persistence turns any graph into a conversational agent with memory, human-in-the-loop approval, time-travel debugging, and streaming — all with a small, composable API.
 
@@ -51,7 +52,7 @@ uv run python 00_hello_world.py
 | `10_persistence.py` | Short-Term Memory | `InMemorySaver`, `thread_id`, multi-turn |
 | `11_message_management.py` | Message Management | `trim_messages`, `RemoveMessage`, summary pattern |
 | `12_long_term_memory.py` | Long-Term Memory Store | `InMemoryStore`, `get_store()`, `store.put()`, `store.search()` |
-| `13_time_travel.py` | Replay & Fork | `get_state_history()`, `update_state()` |
+| `13_time_travel.py` | Replay & Fork | `get_state_history()`, re-invoking from a past `checkpoint_id` |
 | `14_human_in_the_loop.py` | Human-in-the-Loop | `interrupt()`, `Command(resume=...)` |
 | `15_retry_policies.py` | Retry Policies | `RetryPolicy`, `add_node(..., retry_policy=...)` |
 | `16_map_reduce.py` | Map-Reduce (Fan-out) | `Send`, parallel workers, aggregation |
@@ -61,12 +62,16 @@ uv run python 00_hello_world.py
 | `20_evaluator_optimizer.py` | Evaluator-Optimizer Loop | Conditional looping, structured evaluation |
 | `21_functional_api.py` | Functional API | `@entrypoint`, `@task`, `entrypoint.final`, futures |
 | `22_error_handling_and_caching.py` | Error Handling & Caching | Node-level `error_handler`, `CachePolicy` with TTL |
+| `23_runtime_context.py` | Runtime Context | `context_schema=`, `Runtime[Ctx]`, `runtime.context`/`.store`/`.stream_writer`/`.previous`, `invoke(context=...)` |
+| `24_overwrite_and_deferred_nodes.py` | Bypassing Reducers & Deferred Fan-in | `Overwrite`, `{"__overwrite__": ...}`, `InvalidUpdateError`, `add_node(..., defer=True)` |
+| `25_timeouts_and_durability.py` | Timeouts & Durability | `add_node(..., timeout=)`, `TimeoutPolicy`, `NodeTimeoutError`, `durability="sync"/"async"/"exit"` |
+| `26_event_streaming_v3.py` | Event Streaming (v3) | `stream_events(version="v3")`, `.messages`/`.values`/`.subgraphs`/`.output`/`.interrupts`, `transformers=` |
 
 ## Key dependencies
 
 | Package | Version | Purpose |
 |---------|---------|---------|
-| `langgraph` | >=1.2.6 | Core graph framework |
+| `langgraph` | >=1.2.6 (locked 1.2.10) | Core graph framework |
 | `langchain` | >=1.3.10 | LangChain base library |
 | `langchain-openai` | >=1.2.2 | OpenAI model integration (`ChatOpenAI`) |
 | `pydantic` | >=2.12.5 | State validation and structured outputs |

--- a/langgraph/uv.lock
+++ b/langgraph/uv.lock
@@ -302,7 +302,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.6"
+version = "1.2.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -312,9 +312,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/7a/ea09b05bb0cbddfa43bd34fc581357e87fc3f21a751cc0d419688c3106da/langgraph-1.2.6.tar.gz", hash = "sha256:f9b45a34f13930c94d96cdb76277447ad2cc70ec2d18cd2764d7fdadb36cdc1b", size = 714400, upload-time = "2026-06-18T20:58:21.514Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/1d/a32f3caf4b3d60651656c0d64976b48d168653e81c71bb7512e9a31541aa/langgraph-1.2.10.tar.gz", hash = "sha256:05a183a746ed570a06c7c1b879920163509a75df9e44e92dd2238218d677fd37", size = 723404, upload-time = "2026-07-28T18:33:51.441Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/32/772db1b00a9fe42f50320d1aa20caefb76e621eff1f7218b9918093d631d/langgraph-1.2.6-py3-none-any.whl", hash = "sha256:1cf94d3ca124f84f77ce408fa1b06c3dee680a8aafffe364a8fd5d7d03eb8695", size = 246132, upload-time = "2026-06-18T20:58:20.335Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4d/3fc3e2535ee2c731130d71371848ebc6d4a9d2e8ae6060b11987ba134951/langgraph-1.2.10-py3-none-any.whl", hash = "sha256:52c48bd42fa31a1de0e1c0f0ebfe342e11ca2957b8b3563f83dbd60d8e30f921", size = 247753, upload-time = "2026-07-28T18:33:50.028Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- `langgraph` 1.2.6 → 1.2.10, plus 4 new examples (23 → 26), bringing the folder to 27 examples.
- **The version range has no new client-side features.** All four releases are bug fixes to the opt-in beta `DeltaChannel` / `update_state` path, which no example touches. The bump is justified by those correctness fixes alone; the value in this PR is the four coverage-gap examples, which run unchanged on the existing `>=1.2.6` floor.
- `pyproject.toml` floor is **deliberately unchanged** at `>=1.2.6` — every API the new examples use (`Runtime`, `context_schema`, `Overwrite`, `defer=`, `timeout=`/`TimeoutPolicy`, `durability=`, `stream_events(version="v3")`) already exists at 1.2.6. Only `uv.lock` moves.

## What changed

### Package upgrade
- `langgraph` `1.2.6` → `1.2.10` (lock only; done with `uv lock --upgrade-package langgraph` so no transitive dependency drifts)

### Existing examples fixed
None — no breakage. `DeltaChannel` and `update_state()` appear in zero example files, so the whole 1.2.7–1.2.10 fix range is outside the blast radius.

### New examples added
| # | File | Feature | Docs |
|---|------|---------|------|
| 23 | `23_runtime_context.py` | `StateGraph(..., context_schema=)`, `Runtime[Ctx]` node arg, `runtime.context`/`.store`/`.stream_writer`/`.previous`, `invoke(context=...)` | [use-graph-api#add-runtime-configuration](https://docs.langchain.com/oss/python/langgraph/use-graph-api#add-runtime-configuration) |
| 24 | `24_overwrite_and_deferred_nodes.py` | `Overwrite` + `{"__overwrite__": ...}` JSON form, `InvalidUpdateError` on parallel overwrite, `add_node(..., defer=True)` | [use-graph-api#bypass-reducers-with-overwrite](https://docs.langchain.com/oss/python/langgraph/use-graph-api#bypass-reducers-with-overwrite) |
| 25 | `25_timeouts_and_durability.py` | `add_node(..., timeout=)`, `TimeoutPolicy(run_timeout=, idle_timeout=)`, `NodeTimeoutError` + `RetryPolicy`, `durability="sync"/"async"/"exit"` | [fault-tolerance#timeouts](https://docs.langchain.com/oss/python/langgraph/fault-tolerance#timeouts) |
| 26 | `26_event_streaming_v3.py` | `stream_events(version="v3")` typed projections `.messages`/`.values`/`.subgraphs`/`.output`/`.interrupts`, `transformers=[...]` | [event-streaming](https://docs.langchain.com/oss/python/langgraph/event-streaming) |

Each fills a gap rather than restating an existing example: 23 covers the graph-level runtime API that appeared in **zero** of the 23 existing examples, 24 shows how to *escape* the reducer that `01` teaches and how to fan in over uneven branches that `16` cannot, 25 adds timeouts and durability next to the retries/caching in `15`/`22`, and 26 replaces the v2 `stream_mode` tuples of `08`/`09` with the projection API the docs now lead with.

### Key changes in this range
- **Nothing user-visible.** Verified by source diff at tags 1.2.6 vs 1.2.10: `langgraph/types.py` `__all__` is byte-identical and `langgraph/stream/__init__.py` `__all__` is identical (the v3 projection API already shipped in 1.2.6).
- 1.2.7–1.2.9 — `DeltaChannel` / `update_state` correctness: overwrite-superstep snapshots, `Overwrite` surviving JSON round-trips, valid UUIDs for exit-mode delta task IDs, snapshot-instead-of-stub on a fresh thread, metadata/counter fixes.
- 1.2.10 — typed return overloads for `stream_events(version="v3")` (typing only, no runtime change). `trace_policy` on `add_node` landed and was reverted in the same release, so it is unreachable.

### Notes
- **README factual fix**: the `13_time_travel.py` row claimed the file uses `update_state()`. It does not — it forks by re-invoking with a past checkpoint config. Row corrected.
- `timeout=` is **async-nodes-only** and, non-obviously, `add_node()` accepts a sync node silently while `compile()` is what raises `ValueError`. Example 25 demonstrates this rather than just documenting it.
- v3 streaming is still marked experimental and emits a `LangChainBetaWarning` on stderr; noted in the example docstring and in `OUTPUTS.md`.
- Examples 24 and 25 make no LLM calls, so their output is fully deterministic.

## Configuration
- Examples use **OpenAI** (`gpt-4o-mini`) via `settings.py`
- Dependencies: `langgraph>=1.2.6` (locked 1.2.10), `langchain>=1.3.10`, `langchain-openai>=1.2.2`, `pydantic>=2.12.5`, `pydantic-settings>=2.13.1`, `python-dotenv>=1.2.2`, `grandalf>=0.8`
- Managed with `uv`

## Testing
- `uv sync --frozen` — clean, 46 packages checked.
- `python -m py_compile *.py` — 28/28 files compile.
- All 4 new examples live-run against langgraph 1.2.10, exit 0, output captured verbatim into `OUTPUTS.md`.
- Spot-checked 2 existing examples live on 1.2.10 (`01_state_and_reducers.py`, `13_time_travel.py` — the checkpoint-history example closest to the changed code path); both pass. The remaining 21 existing examples were not re-run: no example imports `DeltaChannel` or calls `update_state()`, so nothing in the 1.2.7–1.2.10 fix range can reach them.
